### PR TITLE
echo 0.11.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "echo" %}
-{% set version = "0.5" %}
+{% set version = "0.11.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,38 +7,52 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: fccacf010ac6d70a59d6f5553f3e50a380c14e1eb56c27eff2dbc5e7ccccc509
+  sha256: 85338c5c6a52113875a9c03cddd77e8d2fc000f241e8d4769a627d0b321d973d
 
 build:
-  noarch: python
   number: 0
-  # no qt support for ppc64le
-  skip: True  # [ppc64le]
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<310]
 
 requirements:
   host:
     - python
     - pip
+    - wheel
+    - setuptools >=61.2
     - setuptools_scm
+    - numpy {{ numpy }}
   run:
     - python
     - numpy
-    - setuptools
-    - qtpy
-    - pyqt
+  run_constrained:
+    - pyqt5 >=5.14
 
 test:
   imports:
     - echo
-    - echo.qt
+    - echo.core
+    - echo.selection
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest --pyargs echo.tests
+  requires:
+    - pip
+    - pytest
+
 
 about:
   home: https://github.com/glue-viz/echo
+  summary: Callback Properties in Python
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: Callback Properties in Python
+  description: |
+    Echo is a small library for attaching callback functions to property state changes.
+  dev_url: https://github.com/glue-viz/echo
+  doc_url: https://echo.readthedocs.io
+  
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,12 +26,11 @@ requirements:
     - wheel
     - setuptools >=61.2
     - setuptools_scm
-    - numpy {{ numpy }}
   run:
     - python
     - numpy
   run_constrained:
-    - pyqt5 >=5.14
+    - pyqt >=5.14
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 85338c5c6a52113875a9c03cddd77e8d2fc000f241e8d4769a627d0b321d973d
+  patches:
+    - patches/0001-fix-license-in-pyproject.toml.patch
 
 build:
   number: 0
@@ -15,6 +17,9 @@ build:
   skip: True  # [py<310]
 
 requirements:
+  build:
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip
@@ -41,15 +46,13 @@ test:
     - pip
     - pytest
 
-
 about:
   home: https://github.com/glue-viz/echo
   summary: Callback Properties in Python
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  description: |
-    Echo is a small library for attaching callback functions to property state changes.
+  description: Echo is a small library for attaching callback functions to property state changes.
   dev_url: https://github.com/glue-viz/echo
   doc_url: https://echo.readthedocs.io
   

--- a/recipe/patches/0001-fix-license-in-pyproject.toml.patch
+++ b/recipe/patches/0001-fix-license-in-pyproject.toml.patch
@@ -1,0 +1,25 @@
+From d2275115ca48f4f293b4a7b9145c2b37b5027391 Mon Sep 17 00:00:00 2001
+From: Andrii Osipov <aosipov@anaconda.com>
+Date: Mon, 23 Jun 2025 05:50:45 -0700
+Subject: [PATCH] fix license in pyproject.toml
+
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 752a5ed..fe2fd88 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -2,7 +2,7 @@
+ name = "echo"
+ description = "Callback Properties in Python"
+ readme = "README.rst"
+-license = "MIT"
++license = {text = "MIT"}
+ maintainers = [ { name = "Chris Beaumont and Thomas Robitaille", email = "thomas.robitaille@gmail.com" } ]
+ authors = [ { name = "Chris Beaumont and Thomas Robitaille", email = "thomas.robitaille@gmail.com" } ]
+ requires-python = ">=3.10"
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
echo 0.11.0 

**Destination channel:** Defaults

### Links

- [PKG-8528]
- dev_url:        https://github.com/glue-viz/echo/tree/v0.11.0
- conda_forge:    https://github.com/conda-forge/echo-feedstock
- pypi:           https://pypi.org/project/echo/0.11.0
- pypi inspector: https://inspector.pypi.io/project/echo/0.11.0

### Explanation of changes:

- new version number


[PKG-8528]: https://anaconda.atlassian.net/browse/PKG-8528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ